### PR TITLE
rename the projet to oxapy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
-name = "oxhttp"
+name = "oxapy"
 version = "0.2.9"
 dependencies = [
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "oxhttp"
+name = "oxapy"
 version = "0.2.9"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "oxhttp"
+name = "oxapy"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OxHTTP
+# OxAPY
 
-_OxHTTP_ is Python HTTP server library build in Rust - a fast, safe and feature-rich HTTP server implementation.
+_OxAPY is Python HTTP server library build in Rust - a fast, safe and feature-rich HTTP server implementation.
 
 ## Features
 
@@ -14,12 +14,12 @@ _OxHTTP_ is Python HTTP server library build in Rust - a fast, safe and feature-
 ## Basic Example
 
 ```python
-from oxhttp import HttpServer, get, Router, Status, Response
+from oxapy import HttpServer, get, Router, Status, Response
 
 
 @get("/")
 def welcome():
-    return Response(Status.OK, "Welcome to OxHTTP!")
+    return Response(Status.OK, "Welcome to OxAPY!")
 
 @get("/hello/{name}")
 def hello(name):

--- a/examples/main.py
+++ b/examples/main.py
@@ -2,7 +2,7 @@ import sqlite3
 from utils import hash_password, create_jwt, check_password
 from middlewares import jwt_middleware
 
-from oxhttp import (
+from oxapy import (
     HttpServer,
     Response,
     Router,

--- a/examples/middlewares.py
+++ b/examples/middlewares.py
@@ -1,4 +1,4 @@
-from oxhttp import Status
+from oxapy import Status
 from utils import decode_jwt
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.8,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "oxhttp"
+name = "oxapy"
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
-description = "OxHttp is http server for python build in rust"
+description = "OxAPY is http server for python build in rust"
 dependencies = ["orjson>=3.10.15"]
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ impl HttpServer {
 }
 
 #[pymodule]
-fn oxhttp(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn oxapy(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<HttpServer>()?;
     m.add_class::<Router>()?;
     m.add_class::<Status>()?;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -138,14 +138,14 @@ impl Router {
 #[pyfunction]
 pub fn static_file(directory: String, path: String, py: Python<'_>) -> PyResult<Route> {
     let pathlib = py.import("pathlib")?;
-    let oxhttp = py.import("oxhttp")?;
+    let oxapy = py.import("oxapy")?;
     let mimetypes = py.import("mimetypes")?;
 
     let globals = &PyDict::new(py);
     globals.set_item("Path", pathlib.getattr("Path")?)?;
     globals.set_item("directory", directory)?;
-    globals.set_item("Status", oxhttp.getattr("Status")?)?;
-    globals.set_item("Response", oxhttp.getattr("Response")?)?;
+    globals.set_item("Status", oxapy.getattr("Status")?)?;
+    globals.set_item("Response", oxapy.getattr("Response")?)?;
     globals.set_item("mimetypes", mimetypes)?;
 
     py.run(

--- a/uv.lock
+++ b/uv.lock
@@ -3,5 +3,5 @@ revision = 1
 requires-python = ">=3.8"
 
 [[package]]
-name = "oxhttp"
+name = "oxapy"
 source = { editable = "." }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated branding and usage examples in the user guides to reflect the new project name.
  
- **Refactor**
  - Renamed public interfaces and messaging from OxHTTP to OxAPY, ensuring a consistent and modernized user experience without altering core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->