### PR TITLE
Feat/ser/wr only

### DIFF
--- a/src/serializer/fields.rs
+++ b/src/serializer/fields.rs
@@ -50,6 +50,8 @@ impl Field {
     ///     max_length (int, optional): Maximum length for string fields.
     ///     pattern (str, optional): Regular expression pattern for validation.
     ///     enum_values (list[str], optional): List of allowed values.
+    ///     read_only (bool, optional): If `True`, the field will be excluded when deserializing. Defaults to `None`.
+    ///     write_only (bool, optional): If `True`, the field will be excluded when serializing. Defaults to `None`.
     ///
     /// Example:
     /// ```python
@@ -190,6 +192,8 @@ macro_rules! define_fields {
                 ///     max_length (int, optional): Maximum length (for string types).
                 ///     pattern (str, optional): Regular expression pattern.
                 ///     enum_values (list[str], optional): List of allowed values.
+                ///     read_only (bool, optional): If `True`, the field will be excluded when deserializing.
+                ///     write_only (bool, optional): If `True`, the field will be excluded when serializing.
                 #[new]
                 #[pyo3(signature=(
                     required=true,

--- a/src/serializer/fields.rs
+++ b/src/serializer/fields.rs
@@ -25,6 +25,10 @@ pub struct Field {
     pub pattern: Option<String>,
     #[pyo3(get)]
     pub enum_values: Option<Vec<String>>,
+    #[pyo3(get)]
+    pub read_only: Option<bool>,
+    #[pyo3(get)]
+    pub write_only: Option<bool>,
 }
 
 #[pymethods]
@@ -62,6 +66,8 @@ impl Field {
         max_length = None,
         pattern = None,
         enum_values = None,
+        read_only = None,
+        write_only = None
     ))]
     #[allow(clippy::too_many_arguments)]
     #[new]
@@ -76,6 +82,8 @@ impl Field {
         max_length: Option<usize>,
         pattern: Option<String>,
         enum_values: Option<Vec<String>>,
+        read_only: Option<bool>,
+        write_only: Option<bool>,
     ) -> Self {
         Self {
             required,
@@ -88,6 +96,8 @@ impl Field {
             max_length,
             pattern,
             enum_values,
+            read_only,
+            write_only,
         }
     }
 }
@@ -191,6 +201,8 @@ macro_rules! define_fields {
                     max_length=None,
                     pattern=None,
                     enum_values=None,
+                    read_only=None,
+                    write_only=None
                 ))]
                 fn new(
                     required: Option<bool>,
@@ -202,6 +214,8 @@ macro_rules! define_fields {
                     max_length: Option<usize>,
                     pattern: Option<String>,
                     enum_values: Option<Vec<String>>,
+                    read_only: Option<bool>,
+                    write_only: Option<bool>
                 ) -> (Self, Field) {
                     (
                         Self,
@@ -216,6 +230,8 @@ macro_rules! define_fields {
                             max_length,
                             pattern,
                             enum_values,
+                            read_only,
+                            write_only,
                         ),
                     )
                 }

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -55,6 +55,8 @@ impl Serializer {
     ///     nullable (bool, optional): Whether the field allows null values (default: False).
     ///     many (bool, optional): Whether the serializer handles multiple objects (default: False).
     ///     context (dict, optional): Additional context information.
+    ///     read_only (bool, optional): If `True`, the serializer will be excluded when deserializing (default: False).
+    ///     write_only (bool, optional): If `True`, the serializer will be excluded when serializing (default: False).
     ///
     /// Returns:
     ///     tuple[Serializer, Field]: A tuple containing the serializer instance and its associated `Field`.
@@ -156,7 +158,7 @@ impl Serializer {
     ///     attr (dict): The data to validate.
     ///
     /// Returns:
-    ///     dict: The validated data.
+    ///     dict: The validated data, with any `read_only` fields removed.
     ///
     /// Raises:
     ///     ValidationException: If validation fails.
@@ -196,6 +198,7 @@ impl Serializer {
     ///
     /// If `many=True`, returns a list of serialized dicts.
     /// Otherwise returns a single dict, or None if no instance.
+    /// Fields marked as `write_only=True` will be excluded from the serialized output.
     ///
     /// Returns:
     ///     dict or list[dict] or None: Serialized representation(s).
@@ -311,6 +314,15 @@ impl Serializer {
         Ok(instance)
     }
 
+    /// Convert a model instance to a Python dictionary.
+    ///
+    /// Processes each field in the model, excluding those marked as `write_only=True`.
+    ///
+    /// Args:
+    ///     instance: The model instance to serialize.
+    ///
+    /// Returns:
+    ///     dict: Dictionary representation of the instance.
     fn to_representation<'l>(
         slf: &Bound<'_, Self>,
         instance: Bound<PyAny>,

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -181,17 +181,19 @@ impl Serializer {
             .validate(&json_value)
             .map_err(|err| ValidationException::new_err(err.to_string()))?;
 
-        for k in attr.keys() {
+        let new_attr = attr.copy()?;
+
+        for k in new_attr.keys() {
             let key = k.to_string();
             if let Ok(field) = slf.getattr(&key) {
                 let field = field.extract::<Field>()?;
                 if field.read_only.unwrap_or_default() {
-                    attr.del_item(&key)?;
+                    new_attr.del_item(&key)?;
                 }
             }
         }
 
-        Ok(attr)
+        Ok(new_attr)
     }
 
     /// Return the serialized representation of the instance(s).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `read_only` and `write_only` flags to serializer fields, allowing fields to be excluded from deserialization or serialization as appropriate.
* **Documentation**
  * Updated documentation to describe the behavior of `read_only` and `write_only` flags in serializers.
* **Tests**
  * Introduced tests to verify correct handling of `read_only` and `write_only` fields during serialization and deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->