### PR TITLE
add async mode method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "oxapy"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "ahash",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxapy"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 authors = ["FITAHIANA Nomeniavo Joe <24nomeniavo@gmail.com>"]
 repository = "https://github.com/j03-dev/oxapy"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <b>OxAPY</b> is Python HTTP server library build in Rust - a fast, safe and feature-rich HTTP server implementation.
 </p>
 
-<a href='https://github.com/j03-dev/oxapy/#'><img src='https://img.shields.io/badge/version-0.6.3-%23b7410e'/></a>
+<a href='https://github.com/j03-dev/oxapy/#'><img src='https://img.shields.io/badge/version-0.6.4-%23b7410e'/></a>
 <a href="https://pepy.tech/projects/oxapy"><img src="https://static.pepy.tech/badge/oxapy" alt="PyPI Downloads"></a>
 
 <p>
@@ -55,6 +55,24 @@ app.attach(router)
 
 if __name__ == "__main__":
     app.run()
+```
+
+## Async Example
+
+```python
+from oxapy import HttpServer, Router
+
+router = Router()
+
+@router.get("/")
+async def home(request):
+    # Asynchronous operations are allowed here
+    data = await fetch_data_from_database()
+    return "Hello, World!"
+
+app = HttpServer(("127.0.0.1", 8000))
+app.attach(router)
+app.async_mode().run()
 ```
 
 ## Middleware Example

--- a/oxapy/__init__.pyi
+++ b/oxapy/__init__.pyi
@@ -403,7 +403,32 @@ class HttpServer:
         server.catchers([not_found])
         ```
         """
-    def run(self, workers:typing.Optional[builtins.int]=None, is_async:bool=False) -> typing.Any:
+    def async_mode(self) -> HttpServer:
+        r"""
+        Enable asynchronous mode for the server.
+
+        In asynchronous mode, request handlers can be asynchronous Python functions
+        (i.e., defined with `async def`). This allows you to perform non-blocking
+        I/O operations within your handlers.
+
+        Returns:
+            HttpServer: A new HttpServer instance configured for asynchronous operation.
+
+        Example:
+        ```python
+        app = HttpServer(("127.0.0.1", 8000))
+
+        @router.get("/")
+        async def home(request):
+            # Asynchronous operations are allowed here
+            data = await fetch_data_from_database()
+            return "Hello, World!"
+
+        app.attach(router)
+        app.async_mode().run()
+        ```
+        """
+    def run(self, workers:typing.Optional[builtins.int]=None) -> typing.Any:
         r"""
         Run the HTTP server.
 

--- a/tests/api.py
+++ b/tests/api.py
@@ -12,7 +12,7 @@ server = HttpServer(("0.0.0.0", 5555))
 server.attach(router)
 
 async def main():
-    await server.run(is_async=True)
+    await server.async_mode().run()
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an async mode to support asynchronous request handlers (non-blocking I/O). Configure the server for async, then start it.
- Refactor
  - API change: the server start method no longer accepts an async flag. Use the new async configuration step before starting. This is breaking.
- Documentation
  - Updated README with an async usage example and refreshed the version badge.
- Tests
  - Updated tests to use the new async configuration flow.
- Chores
  - Bumped version to 0.6.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->